### PR TITLE
Update base.py

### DIFF
--- a/service/base.py
+++ b/service/base.py
@@ -474,7 +474,8 @@ class WebService(Service):
         """
         try:
             payload = self.net_stream(*args, **kwargs)
-            with open(path, 'wb') as f:
+            p = os.path.join(mw.pm.profileFolder(),'collection.media',path)            
+            with open(p, 'wb') as f:            
                 f.write(payload)
                 f.close()
             return True


### PR DESCRIPTION
Fix the issue where audio cannot be played. 
The original program saves the downloaded audio files under %appdata%\Local\Programs\Anki, but they should be placed in Roaming\Anki2\<profile_name>\collection.media.